### PR TITLE
Switch to OAuth for auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,23 +32,32 @@ The settings.ini file contains the configuration for this utility.  There are fi
 
 The `debug` key controls verbose logging.  For production use you probably want this to be false.
 
-2. JWT:
+2. Zoom:
 
-This is the [JSON Web Token](https://jwt.io/) configuration data you get from Zoom.  For now ETH will
-have to manually create their app at https://marketplace.zoom.us/develop/create from the main ETH account.
-Longer term the goal here would be to have this in the Zoom market, but that is still pending.
+This is where you configure your [Server-To-Server OAUTH](https://developers.zoom.us/docs/internal-apps/s2s-oauth/)
+application.  You *must* create such an application in your account - this tool is not something you can subscribe to
+directly.
 
 To create the app:
-- Sign in as the root account at marketplace.zoom.us
-- Go to https://marketplace.zoom.us/develop/create
-- Create JWT credentials, you will need the API Key and Secret in the config file
+- Create a Server-to-Server OAuth App within the Zoom App Marketplace.  Beware, there is an standard (non
+  server-to-server) OAuth application type which will not work for this application.
+  - Your `Account ID`, `Client ID`, and `Client Secret` should be copied into the `Zoom` section in settings.ini.
+- Grant the following scopes to your application:
+  - `/contact:read:admin`, which is required for user search to work
+  - `/user:read:admin`, which is required for user search to work, and user data to populate
+  - `/recording:read:admin`, which is required to read the recording data
 
 3. Webhook:
 
 This utilty supports event-driven ingestion.  When a meeting finishes it would be automatically ingested.
-This is *disabled* by default, so for now leave this section alone.  The URL and port are where the webhook
-should listen, and must match the settings in Zoom, were you to conigure webhooks.  As of this writing (2020-10-04)
-this has not been tested with the latest code, but is a high priority community requirement for long term release.
+This is *disabled* unless both a default workflow id, and one of series or acl id are set.  The webhook must also be
+configured on Zoom's end, which is done in the Zoom app under the `Feature` section of the Zoom app you created above.
+To accomplish this you must:
+- Enable `Event Subscriptions` for the following events:
+  - `All Recordings have completed`
+  - `Recording Renamed` events.
+For security purposes the `Secret Token` from the `Features` section in Zoom should be copied to the `secret` config
+key.  Without this secret the incoming webhook POSTs are not verified to be originating from Zoom's servers.
 
 4. Opencast:
 

--- a/etc/zoom-ingest/settings.ini
+++ b/etc/zoom-ingest/settings.ini
@@ -1,6 +1,8 @@
 [Zoom]
-JWT_Key:
-JWT_Secret:
+#Configure these in the Server-to-Server OAuth App Credentials
+oauth_account_id:
+oauth_client_id:
+oauth_client_secret:
 GDPR: false
 
 [Webhook]
@@ -11,7 +13,7 @@ default_series_id:
 default_workflow_id:
 #ACL ID is optional if the default series id is set.  If both are set this override the series default ACL.
 default_acl_id:
-#Give this a value to require that the incoming webhook events have a pre-shared secret.  Configure this in your Zoom app.
+#A secret to ensure requests come from Zoom.  This is generated in the Feature page of the Zoom app
 secret:
 
 [Opencast]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-zoomus>=1.1.6
+zoomus>=1.2.0
 flask>=1.1.2
 gunicorn>=20.0.4
 pika>=1.1.0

--- a/webhook.py
+++ b/webhook.py
@@ -388,9 +388,8 @@ def do_bulk():
 @db.with_session
 def do_POST(dbs):
     logger.debug("POST received")
-    logger.info(request.headers)
-    logger.info(request.data)
-    #Check UTF8 safeness of this
+
+#Check UTF8 safeness of this
     body = request.get_json(force=True)
     zoom_req_hmac = request.headers['X-Zm-Signature']
     zoom_req_ts = request.headers['X-Zm-Request-Timestamp']

--- a/webhook.py
+++ b/webhook.py
@@ -6,6 +6,8 @@ import urllib.parse
 from datetime import datetime, date, timedelta
 from urllib.parse import urlencode, parse_qs
 from requests import HTTPError
+import hmac
+import hashlib
 
 from flask import Flask, request, render_template, render_template_string, redirect
 
@@ -60,6 +62,13 @@ try:
     WEBHOOK_SERIES = (config['Webhook']['default_series_id']).strip()
     WEBHOOK_ACL = (config['Webhook']['default_acl_id']).strip()
     WEBHOOK_WORKFLOW = (config['Webhook']['default_workflow_id']).strip()
+    WEBHOOK_SECRET = (config['Webhook']['secret']).strip()
+    if len(WEBHOOK_SECRET) != 0:
+        logger.debug(f"Webhook secret configured: { WEBHOOK_SECRET[0:3] }XXX{ WEBHOOK_SECRET[-3:] }")
+    else:
+        logger.warn(f"Webhook secret not configured, not validating incoming webhook calls!")
+        WEBHOOK_SECRET = None
+
     if len(WEBHOOK_WORKFLOW) == 0 and not (len(WEBHOOK_SERIES) > 0 or len(WEBHOOK_ACL) > 0):
         WEBHOOK_ENABLE = False
         logger.info("Webhook is not completely configured and is not functional!")
@@ -69,12 +78,6 @@ try:
         logger.debug(f"Webhook events will be ingested to series ID '{WEBHOOK_SERIES}'")
         logger.debug(f"Webhook events will be ingested with ACL ID '{WEBHOOK_ACL}'")
         logger.debug(f"Webhook events will be ingested with workflow ID '{WEBHOOK_WORKFLOW}'")
-        WEBHOOK_SECRET = (config['Webhook']['secret']).strip()
-        if len(WEBHOOK_SECRET) != 0:
-            logger.debug(f"Webhook pre-shared secret configured: { WEBHOOK_SECRET[0:3] }XXX{ WEBHOOK_SECRET[-3:] }")
-        else:
-            logger.debug(f"Webhook pre-shared secre not configured")
-            WEBHOOK_SECRET = None
 except KeyError as err:
     sys.exit("Key {0} was not found".format(err))
 except ValueError as err:
@@ -385,19 +388,44 @@ def do_bulk():
 @db.with_session
 def do_POST(dbs):
     logger.debug("POST received")
+    logger.info(request.headers)
+    logger.info(request.data)
+    #Check UTF8 safeness of this
+    body = request.get_json(force=True)
+    zoom_req_hmac = request.headers['X-Zm-Signature']
+    zoom_req_ts = request.headers['X-Zm-Request-Timestamp']
 
+    #First check that the request originated from Zoom using the webhook secret
+    if WEBHOOK_SECRET:
+        #NB: body (above) formats the incoming json.  This message must contain *exactly* what Zoom sends since it's being hashed, so we use the raw request.data way instead.
+        message = f"v0:{ zoom_req_ts }:{ request.data.decode('utf-8') }"
+        calc_hmac = "v0=" + hmac.new(key=WEBHOOK_SECRET.encode('utf-8'),
+                             msg=message.encode('utf-8'),
+                             digestmod=hashlib.sha256).hexdigest()
+        if zoom_req_hmac != calc_hmac:
+            logger.error("Request signature does not match")
+            return render_template_string("Request signature does not match"), 400
+
+    #Zoom requires validating the endpoint, and also re-verifies periodically
+    try:
+        event = body['event']
+        if 'endpoint.url_validation' == event:
+            zoom_plain_token = body['payload']['plainToken']
+            calc_hmac = hmac.new(key=WEBHOOK_SECRET.encode('utf-8'),
+                                 msg=zoom_plain_token.encode('utf-8'),
+                                 digestmod=hashlib.sha256).hexdigest()
+            logger.debug("Endpoint validation POST recieved successfully")
+            return render_template_string(f'{{ "plainToken": "{  zoom_plain_token }", "encryptedToken": "{ calc_hmac }" }}')
+    except Exception as e:
+        logger.exception("Endpoint validation logic triggered an exception")
+        return render_template_string("Endpoint Validation Failed")
+    
     #If this header is missing this will throw a 400 automatically
     content_length = int(request.headers.get('Content-Length'))
     if content_length < 5:
         logger.error("Content too short")
         return render_template_string("No data received"), 400
 
-    #Check UTF8 safeness of this
-    body = request.get_json(force=True)
-    if WEBHOOK_SECRET:
-        if 'authorization' not in request.headers or WEBHOOK_SECRET != request.headers.get('authorization'):
-            logger.error("Request pre-shared secret is not set or incorrect")
-            return render_template_string("Request pre-shared secret is not set or incorrect"), 400
     if "payload" not in body:
         logger.error("Payload is missing")
         return render_template_string("Missing payload field in webhook body"), 400

--- a/zingest/zoom.py
+++ b/zingest/zoom.py
@@ -8,67 +8,7 @@ import time
 from requests import HTTPError
 
 import jwt
-
-import zoomus.util
-zoomus.util.API_GDPR = "gdpr"
-
-import zoomus.client
-zoomus.client.API_BASE_URIS = {
-    zoomus.util.API_VERSION_1: "https://api.zoom.us/v1",
-    zoomus.util.API_VERSION_2: "https://api.zoom.us/v2",
-    zoomus.util.API_GDPR: "https://eu01api-www4local.zoom.us/v2",
-}
-
 from zoomus import ZoomClient
-def patched_init(
-        self,
-        api_key,
-        api_secret,
-        data_type="json",
-        timeout=15,
-        version=zoomus.util.API_VERSION_2,
-        base_uri=None,
-    ):
-        """Create a new Zoom client
-
-        :param api_key: The Zooom.us API key
-        :param api_secret: The Zoom.us API secret
-        :param data_type: The expected return data type. Either 'json' or 'xml'
-        :param timeout: The time out to use for API requests
-        :param version: The API version to use (Default is V2). The available
-                        options are API_VERSION_1 (deprecated by Zoom),
-                        or API_VERSION_2 (default)
-        :param base_uri: Set the base URI to use. By default this is chosen
-                         based on the API version chosen, but it can be
-                         overriden so that the GDPR compliant base URI can
-                         be used in the EU.
-        """
-        try:
-            base_uri = base_uri or zoomus.client.API_BASE_URIS[version]
-            self.components = zoomus.client.COMPONENT_CLASSES[version].copy()
-        except KeyError:
-            raise RuntimeError("API version not supported: %s" % version)
-
-        super(ZoomClient, self).__init__(base_uri=base_uri, timeout=timeout)
-
-        # Setup the config details
-        self.config = {
-            "api_key": api_key,
-            "api_secret": api_secret,
-            "data_type": data_type,
-            "version": version,
-            "base_uri": base_uri,
-            "token": zoomus.util.generate_jwt(api_key, api_secret),
-        }
-
-        # Instantiate the components
-        for key in self.components.keys():
-            self.components[key] = self.components[key](
-                base_uri=base_uri, config=self.config
-            )
-ZoomClient.__init__ = patched_init
-
-
 
 from zingest import db
 from zingest.common import BadWebhookData, NoMp4Files, get_config

--- a/zingest/zoom.py
+++ b/zingest/zoom.py
@@ -7,7 +7,14 @@ from urllib.parse import quote
 import time
 from requests import HTTPError
 
-from zoomus import ZoomClient
+from zoomus import ZoomClient, util
+def refresh_token(self):
+    self.config["token"] = util.generate_token(
+            self.config["oauth_uri"],
+            self.config["api_key"],
+            self.config["api_secret"],
+            self.config["api_account_id"])
+ZoomClient.refresh_token = refresh_token
 
 from zingest import db
 from zingest.common import BadWebhookData, NoMp4Files, get_config


### PR DESCRIPTION
This PR...
- Reversing the monkeypatched GDPR compliance since the upstream library now handles this correctly.
- Zoom client boots, however accessing the API still fails.
- Updating Zoom to use OAuth auth type since Zoom is sunsetting the JWT integration Sept 1
- MONKEYPATCH: This fixes an upstream bug, which is filed as https://github.com/prschmid/zoomus/pull/356

Basically just revert an old monkeypatch, update code and docs to use OAuth, and add a new monkeypatch
